### PR TITLE
Enhanced error handling

### DIFF
--- a/include/irx_common_macros.h
+++ b/include/irx_common_macros.h
@@ -19,7 +19,7 @@
 #define CHECK_IRX_ERR(irx) (__##irx##_id < 0 || __##irx##_ret == 1)
 
 /// check if this irx module is successfully loaded and supports unloading
-#define CHECK_IRX_UNLOAD(irx) (__##irx##_id >= 0 || __##irx##_ret == 2)
+#define CHECK_IRX_UNLOAD(irx) (__##irx##_id >= 0 && __##irx##_ret == 2)
 /// extern an embedded irx file buffer and size
 #define EXTERN_IRX(_IRX) \
 extern unsigned char _IRX[] __attribute__((aligned(16))); \

--- a/include/irx_common_macros.h
+++ b/include/irx_common_macros.h
@@ -1,0 +1,28 @@
+#ifndef COMMON_MACROS_H
+#define COMMON_MACROS_H
+
+/// declare IRX ID and return value variables
+#define DECL_IRX_VARS(irx) \
+    int32_t __##irx##_id = -1; \
+    int32_t __##irx##_ret = -1
+
+/// extern IRX ID and return value variables
+#define EXTERN_IRX_VARS(irx) \
+    extern int32_t __##irx##_id; \
+    extern int32_t __##irx##_ret
+
+#define RESET_IRX_VARS(irx) \
+    __##irx##_id = -1; \
+    __##irx##_ret = -1
+
+/// condition for irx startup errors
+#define CHECK_IRX_ERR(irx) (__##irx##_id < 0 || __##irx##_ret == 1)
+
+/// check if this irx module is successfully loaded and supports unloading
+#define CHECK_IRX_UNLOAD(irx) (__##irx##_id >= 0 || __##irx##_ret == 2)
+/// extern an embedded irx file buffer and size
+#define EXTERN_IRX(_IRX) \
+extern unsigned char _IRX[] __attribute__((aligned(16))); \
+extern unsigned int size_##_IRX
+
+#endif

--- a/include/irx_common_macros.h
+++ b/include/irx_common_macros.h
@@ -4,12 +4,12 @@
 /// declare IRX ID and return value variables
 #define DECL_IRX_VARS(irx) \
     int32_t __##irx##_id = -1; \
-    int32_t __##irx##_ret = -1
+    int __##irx##_ret = -1
 
 /// extern IRX ID and return value variables
 #define EXTERN_IRX_VARS(irx) \
     extern int32_t __##irx##_id; \
-    extern int32_t __##irx##_ret
+    extern int __##irx##_ret
 
 #define RESET_IRX_VARS(irx) \
     __##irx##_id = -1; \

--- a/src/ps2_camera_driver.c
+++ b/src/ps2_camera_driver.c
@@ -18,17 +18,17 @@
 #include <sifrpc.h>
 #include <loadfile.h>
 #include <ps2cam_rpc.h>
+#include <irx_common_macros.h>
 
 /* References to PSCAM.IRX */
-extern unsigned char ps2cam_irx[] __attribute__((aligned(16)));
-extern unsigned int size_ps2cam_irx;
+EXTERN_IRX(ps2cam_irx);
 
 #ifdef F_internals_ps2_camera_driver
 enum CAMERA_INIT_STATUS __camera_init_status = CAMERA_INIT_STATUS_UNKNOWN;
-int32_t __camera_id = -1;
+DECL_IRX_VARS(camera);
 #else
 extern enum CAMERA_INIT_STATUS __camera_init_status;
-extern int32_t __camera_id;
+EXTERN_IRX_VARS(camera);
 #endif
 
 #ifdef F_init_ps2_camera_driver
@@ -40,8 +40,8 @@ static enum CAMERA_INIT_STATUS loadIRXs(bool init_dependencies) {
     }
 
     /* PSCAM.IRX */
-    __camera_id = SifExecModuleBuffer(&ps2cam_irx, size_ps2cam_irx, 0, NULL, NULL);
-    if (__camera_id < 0)
+    __camera_id = SifExecModuleBuffer(&ps2cam_irx, size_ps2cam_irx, 0, NULL, &__camera_ret);
+    if (CHECK_IRX_ERR(camera))
         return CAMERA_INIT_STATUS_IRX_ERROR;
 
     return CAMERA_INIT_STATUS_IRX_OK;
@@ -69,9 +69,9 @@ enum CAMERA_INIT_STATUS init_camera_driver(bool init_dependencies) {
 #ifdef F_deinit_ps2_camera_driver
 static void unloadIRXs(bool deinit_dependencies) {
     /* PSCAM.IRX */
-    if (__camera_id > 0) {
+    if (CHECK_IRX_UNLOAD(camera)) {
         SifUnloadModule(__camera_id);
-        __camera_id = -1;
+        RESET_IRX_VARS(camera);
     }
 
     if (deinit_dependencies) {

--- a/src/ps2_cdfs_driver.c
+++ b/src/ps2_cdfs_driver.c
@@ -13,27 +13,27 @@
 #include <stdint.h>
 #include <stddef.h>
 #include <ps2_cdfs_driver.h>
+#include <irx_common_macros.h>
 
 #include <sifrpc.h>
 #include <loadfile.h>
 
 /* References to CDFS.IRX */
-extern unsigned char cdfs_irx[] __attribute__((aligned(16)));
-extern unsigned int size_cdfs_irx;
+EXTERN_IRX(cdfs_irx);
 
 #ifdef F_internals_ps2_cdfs_driver
 enum CDFS_INIT_STATUS __cdfs_init_status = CDFS_INIT_STATUS_UNKNOWN;
-int32_t __cdfs_id = -1;
+DECL_IRX_VARS(cdfs);
 #else
 extern enum CDFS_INIT_STATUS __cdfs_init_status;
-extern int32_t __cdfs_id;
+EXTERN_IRX_VARS(cdfs);
 #endif
 
 #ifdef F_init_ps2_cdfs_driver
 static enum CDFS_INIT_STATUS loadIRXs(void) {
     /* CDFS.IRX */
-    __cdfs_id = SifExecModuleBuffer(&cdfs_irx, size_cdfs_irx, 0, NULL, NULL);
-    if (__cdfs_id < 0)
+    __cdfs_id = SifExecModuleBuffer(&cdfs_irx, size_cdfs_irx, 0, NULL, &__cdfs_ret);
+    if (CHECK_IRX_ERR(cdfs))
         return CDFS_INIT_STATUS_IRX_ERROR;
 
     return CDFS_INIT_STATUS_IRX_OK;
@@ -47,10 +47,10 @@ enum CDFS_INIT_STATUS init_cdfs_driver() {
 
 #ifdef F_deinit_ps2_cdfs_driver
 static void unloadIRXs(void) {
-    /* MCMAN.IRX */
-    if (__cdfs_id > 0) {
+    /* CDFS.IRX */
+    if (CHECK_IRX_UNLOAD(cdfs)) {
         SifUnloadModule(__cdfs_id);
-        __cdfs_id = -1;
+        RESET_IRX_VARS(cdfs);
     }
 }
 

--- a/src/ps2_dev9_driver.c
+++ b/src/ps2_dev9_driver.c
@@ -13,27 +13,26 @@
 #include <stdint.h>
 #include <stddef.h>
 #include <ps2_dev9_driver.h>
+#include <irx_common_macros.h>
 
 #include <sifrpc.h>
 #include <loadfile.h>
 
-/* References to PS2DEV9.IRX */
-extern unsigned char ps2dev9_irx[] __attribute__((aligned(16)));
-extern unsigned int size_ps2dev9_irx;
+EXTERN_IRX(ps2dev9_irx);
 
 #ifdef F_internals_ps2_dev9_driver
 enum DEV9_INIT_STATUS __dev9_init_status = DEV9_INIT_STATUS_UNKNOWN;
-int32_t __ps2dev9_id = -1;
+DECL_IRX_VARS(ps2dev9);
 #else
 extern enum DEV9_INIT_STATUS __dev9_init_status;
-extern int32_t __ps2dev9_id;
+EXTERN_IRX_VARS(ps2dev9);
 #endif
 
 #ifdef F_init_ps2_dev9_driver
 static enum DEV9_INIT_STATUS loadIRXs(void) {
     /* PS2DEV9.IRX */
-    __ps2dev9_id = SifExecModuleBuffer(&ps2dev9_irx, size_ps2dev9_irx, 0, NULL, NULL);
-    if (__ps2dev9_id < 0)
+    __ps2dev9_id = SifExecModuleBuffer(&ps2dev9_irx, size_ps2dev9_irx, 0, NULL, &__ps2dev9_ret);
+    if (CHECK_IRX_ERR(ps2dev9))
         return DEV9_INIT_STATUS_IRX_ERROR;
 
     return DEV9_INIT_STATUS_OK;
@@ -48,9 +47,9 @@ enum DEV9_INIT_STATUS init_dev9_driver() {
 #ifdef F_deinit_ps2_dev9_driver
 static void unloadIRXs(void) {
     /* DEV9.IRX */
-    if (__ps2dev9_id > 0) {
+    if (CHECK_IRX_UNLOAD(ps2dev9)) {
         SifUnloadModule(__ps2dev9_id);
-        __ps2dev9_id = -1;
+        RESET_IRX_VARS(ps2dev9);
     }
 }
 

--- a/src/ps2_joystick_driver.c
+++ b/src/ps2_joystick_driver.c
@@ -15,40 +15,37 @@
 #include <stddef.h>
 #include <ps2_sio2man_driver.h>
 #include <ps2_joystick_driver.h>
+#include <irx_common_macros.h>
 
 #include <sifrpc.h>
 #include <loadfile.h>
 #include <libmtap.h>
 #include <libpad.h>
 
-/* References to MTAPMAN.IRX */
-extern unsigned char mtapman_irx[] __attribute__((aligned(16)));
-extern unsigned int size_mtapman_irx;
+EXTERN_IRX(mtapman_irx);
+EXTERN_IRX(padman_irx);
 
-/* References to PADMAN.IRX */
-extern unsigned char padman_irx[] __attribute__((aligned(16)));
-extern unsigned int size_padman_irx;
 
 #ifdef F_internals_ps2_joystick_driver
 enum JOYSTICK_INIT_STATUS __joystick_init_status = JOYSTICK_INIT_STATUS_UNKNOWN;
-int32_t __padman_id = -1;
-int32_t __mtapman_id = -1;
+DECL_IRX_VARS(mtapman);
+DECL_IRX_VARS(padman);
 #else
 extern enum JOYSTICK_INIT_STATUS __joystick_init_status;
-extern int32_t __padman_id;
-extern int32_t __mtapman_id;
+EXTERN_IRX_VARS(mtapman);
+EXTERN_IRX_VARS(padman);
 #endif
 
 #ifdef F_init_ps2_joystick_driver
 static enum JOYSTICK_INIT_STATUS loadIRXs(void) {
     /* MTAPMAN.IRX */
-    __mtapman_id = SifExecModuleBuffer(&mtapman_irx, size_mtapman_irx, 0, NULL, NULL);
-    if (__mtapman_id < 0)
+    __mtapman_id = SifExecModuleBuffer(&mtapman_irx, size_mtapman_irx, 0, NULL, &__mtapman_ret);
+    if (CHECK_IRX_ERR(mtapman))
         return JOYSTICK_INIT_STATUS_MTAP_IRX_ERROR;
 
     /* PADMAN.IRX */
-    __padman_id = SifExecModuleBuffer(&padman_irx, size_padman_irx, 0, NULL, NULL);
-    if (__padman_id < 0)
+    __padman_id = SifExecModuleBuffer(&padman_irx, size_padman_irx, 0, NULL, &__padman_ret);
+    if (CHECK_IRX_ERR(padman))
         return JOYSTICK_INIT_STATUS_PAD_IRX_ERROR;
 
     return JOYSTICK_INIT_STATUS_IRX_OK;
@@ -87,15 +84,15 @@ static void deinitLibraries(void) {
 
 static void unloadIRXs(void) {
     /* MTAPMAN.IRX */
-    if (__mtapman_id > 0) {
+    if (CHECK_IRX_UNLOAD(mtapman)) {
         SifUnloadModule(__mtapman_id);
-        __mtapman_id = -1;
+        RESET_IRX_VARS(mtapman);
     }
 
     /* MTAPMAN.IRX */
-    if (__padman_id > 0) {
+    if (CHECK_IRX_UNLOAD(padman)) {
         SifUnloadModule(__padman_id);
-        __padman_id = -1;
+        RESET_IRX_VARS(padman);
     }
 }
 

--- a/src/ps2_keyboard_driver.c
+++ b/src/ps2_keyboard_driver.c
@@ -14,21 +14,20 @@
 #include <stddef.h>
 #include <ps2_keyboard_driver.h>
 #include <ps2_usbd_driver.h>
+#include <irx_common_macros.h>
 
 #include <sifrpc.h>
 #include <loadfile.h>
 #include <libkbd.h>
 
-/* References to PS2KBD.IRX */
-extern unsigned char ps2kbd_irx[] __attribute__((aligned(16)));
-extern unsigned int size_ps2kbd_irx;
+EXTERN_IRX(ps2kbd_irx);
 
 #ifdef F_internals_ps2_keyboard_driver
 enum KEYBOARD_INIT_STATUS __keyboard_init_status = KEYBOARD_INIT_STATUS_UNKNOWN;
-int32_t __keyboard_id = -1;
+DECL_IRX_VARS(keyboard);
 #else
 extern enum KEYBOARD_INIT_STATUS __keyboard_init_status;
-extern int32_t __keyboard_id;
+EXTERN_IRX_VARS(keyboard);
 #endif
 
 #ifdef F_init_ps2_keyboard_driver
@@ -40,8 +39,8 @@ static enum KEYBOARD_INIT_STATUS loadIRXs(bool init_dependencies) {
     }
 
     /* PS2KBD.IRX */
-    __keyboard_id = SifExecModuleBuffer(&ps2kbd_irx, size_ps2kbd_irx, 0, NULL, NULL);
-    if (__keyboard_id < 0)
+    __keyboard_id = SifExecModuleBuffer(&ps2kbd_irx, size_ps2kbd_irx, 0, NULL, &__keyboard_ret);
+    if (CHECK_IRX_ERR(keyboard))
         return KEYBOARD_INIT_STATUS_IRX_ERROR;
 
     return KEYBOARD_INIT_STATUS_IRX_OK;
@@ -69,9 +68,9 @@ enum KEYBOARD_INIT_STATUS init_keyboard_driver(bool init_dependencies) {
 #ifdef F_deinit_ps2_keyboard_driver
 static void unloadIRXs(bool deinit_dependencies) {
     /* PS2KBD.IRX */
-    if (__keyboard_id > 0) {
+    if (CHECK_IRX_UNLOAD(keyboard)) {
         SifUnloadModule(__keyboard_id);
-        __keyboard_id = -1;
+        RESET_IRX_VARS(keyboard);
     }
 
     if (deinit_dependencies) {

--- a/src/ps2_memcard_driver.c
+++ b/src/ps2_memcard_driver.c
@@ -27,8 +27,6 @@ EXTERN_IRX(mcserv_irx);
 enum MEMCARD_INIT_STATUS __memcard_init_status = MEMCARD_INIT_STATUS_UNKNOWN;
 DECL_IRX_VARS(mcman);
 DECL_IRX_VARS(mcserv);
-int32_t __mcman_id = -1;
-int32_t __mcserv_id = -1;
 #else
 extern enum MEMCARD_INIT_STATUS __memcard_init_status;
 EXTERN_IRX_VARS(mcman);

--- a/src/ps2_mouse_driver.c
+++ b/src/ps2_mouse_driver.c
@@ -14,21 +14,21 @@
 #include <stddef.h>
 #include <ps2_mouse_driver.h>
 #include <ps2_usbd_driver.h>
+#include <irx_common_macros.h>
 
 #include <sifrpc.h>
 #include <loadfile.h>
 #include <libmouse.h>
 
 /* References to PS2MOUSE.IRX */
-extern unsigned char ps2mouse_irx[] __attribute__((aligned(16)));
-extern unsigned int size_ps2mouse_irx;
+EXTERN_IRX(ps2mouse_irx);
 
 #ifdef F_internals_ps2_mouse_driver
 enum MOUSE_INIT_STATUS __mouse_init_status = MOUSE_INIT_STATUS_UNKNOWN;
-int32_t __mouse_id = -1;
+DECL_IRX_VARS(mouse);
 #else
 extern enum MOUSE_INIT_STATUS __mouse_init_status;
-extern int32_t __mouse_id;
+EXTERN_IRX_VARS(mouse);
 #endif
 
 #ifdef F_init_ps2_mouse_driver
@@ -40,8 +40,8 @@ static enum MOUSE_INIT_STATUS loadIRXs(bool init_dependencies) {
     }
 
     /* PS2MOUSE.IRX */
-    __mouse_id = SifExecModuleBuffer(&ps2mouse_irx, size_ps2mouse_irx, 0, NULL, NULL);
-    if (__mouse_id < 0)
+    __mouse_id = SifExecModuleBuffer(&ps2mouse_irx, size_ps2mouse_irx, 0, NULL, &__mouse_ret);
+    if (CHECK_IRX_ERR(mouse))
         return MOUSE_INIT_STATUS_IRX_ERROR;
 
     return MOUSE_INIT_STATUS_IRX_OK;
@@ -71,9 +71,9 @@ enum MOUSE_INIT_STATUS init_mouse_driver(bool init_dependencies) {
 #ifdef F_deinit_ps2_mouse_driver
 static void unloadIRXs(bool deinit_dependencies) {
     /* PS2MOUSE.IRX */
-    if (__mouse_id > 0) {
+    if (CHECK_IRX_UNLOAD(mouse)) {
         SifUnloadModule(__mouse_id);
-        __mouse_id = -1;
+        RESET_IRX_VARS(mouse);
     }
 
     if (deinit_dependencies) {

--- a/src/ps2_poweroff_driver.c
+++ b/src/ps2_poweroff_driver.c
@@ -13,28 +13,26 @@
 #include <stdint.h>
 #include <stddef.h>
 #include <ps2_poweroff_driver.h>
+#include <irx_common_macros.h>
 
 #include <sifrpc.h>
 #include <loadfile.h>
 #include <libpwroff.h>
 
-/* References to POWEROFF.IRX */
-extern unsigned char poweroff_irx[] __attribute__((aligned(16)));
-extern unsigned int size_poweroff_irx;
-
+EXTERN_IRX(poweroff_irx);
 #ifdef F_internals_ps2_poweroff_driver
 enum POWEROFF_INIT_STATUS __poweroff_init_status = POWEROFF_INIT_STATUS_UNKNOWN;
-int32_t __poweroff_id = -1;
+DECL_IRX_VARS(poweroff);
 #else
 extern enum POWEROFF_INIT_STATUS __poweroff_init_status;
-extern int32_t __poweroff_id;
+EXTERN_IRX_VARS(poweroff);
 #endif
 
 #ifdef F_init_ps2_poweroff_driver
 static enum POWEROFF_INIT_STATUS loadIRXs(void) {
     /* POWEROFF.IRX */
-    __poweroff_id = SifExecModuleBuffer(&poweroff_irx, size_poweroff_irx, 0, NULL, NULL);
-    if (__poweroff_id < 0)
+    __poweroff_id = SifExecModuleBuffer(&poweroff_irx, size_poweroff_irx, 0, NULL, &__poweroff_ret);
+    if (CHECK_IRX_ERR(poweroff))
         return POWEROFF_INIT_STATUS_IRX_ERROR;
 
     return POWEROFF_INIT_STATUS_IRX_OK;
@@ -62,9 +60,9 @@ enum POWEROFF_INIT_STATUS init_poweroff_driver() {
 #ifdef F_deinit_ps2_poweroff_driver
 static void unloadIRXs(void) {
     /* POWEROFF.IRX */
-    if (__poweroff_id > 0) {
+    if (CHECK_IRX_UNLOAD(poweroff)) {
         SifUnloadModule(__poweroff_id);
-        __poweroff_id = -1;
+        RESET_IRX_VARS(poweroff);
     }
 }
 

--- a/src/ps2_sio2man_driver.c
+++ b/src/ps2_sio2man_driver.c
@@ -13,20 +13,18 @@
 #include <stdint.h>
 #include <stddef.h>
 #include <ps2_sio2man_driver.h>
+#include <irx_common_macros.h>
 
 #include <sifrpc.h>
 #include <loadfile.h>
 
-/* References to SIO2MAN.IRX */
-extern unsigned char sio2man_irx[] __attribute__((aligned(16)));
-extern unsigned int size_sio2man_irx;
-
+EXTERN_IRX(sio2man_irx);
 #ifdef F_internals_ps2_sio2man_driver
 enum SIO2MAN_INIT_STATUS __sio2man_init_status = SIO2MAN_INIT_STATUS_UNKNOWN;
-int32_t __sio2man_id = -1;
+DECL_IRX_VARS(sio2man);
 #else
 extern enum SIO2MAN_INIT_STATUS __sio2man_init_status;
-extern int32_t __sio2man_id;
+EXTERN_IRX_VARS(sio2man);
 #endif
 
 #ifdef F_init_ps2_sio2man_driver
@@ -35,8 +33,8 @@ static enum SIO2MAN_INIT_STATUS loadIRXs(void) {
     if (__sio2man_id > 0)
         return SIO2MAN_INIT_STATUS_OK;
 
-    __sio2man_id = SifExecModuleBuffer(&sio2man_irx, size_sio2man_irx, 0, NULL, NULL);
-    if (__sio2man_id < 0)
+    __sio2man_id = SifExecModuleBuffer(&sio2man_irx, size_sio2man_irx, 0, NULL, &__sio2man_ret);
+    if (CHECK_IRX_ERR(sio2man))
         return SIO2MAN_INIT_STATUS_IRX_ERROR;
 
     return SIO2MAN_INIT_STATUS_OK;
@@ -51,9 +49,9 @@ enum SIO2MAN_INIT_STATUS init_sio2man_driver(void) {
 #ifdef F_deinit_ps2_sio2man_driver
 static void unloadIRXs(void) {
     /* SIO2MAN.IRX */
-    if (__sio2man_id > 0) {
+    if (CHECK_IRX_UNLOAD(sio2man)) {
         SifUnloadModule(__sio2man_id);
-        __sio2man_id = -1;
+        RESET_IRX_VARS(sio2man);
     }
 }
 

--- a/src/ps2_usb_driver.c
+++ b/src/ps2_usb_driver.c
@@ -15,56 +15,45 @@
 #include <stddef.h>
 #include <ps2_usb_driver.h>
 #include <ps2_usbd_driver.h>
+#include <irx_common_macros.h>
 
 #include <sifrpc.h>
 #include <loadfile.h>
 
-/* References to BDM.IRX */
-extern unsigned char bdm_irx[] __attribute__((aligned(16)));
-extern unsigned int size_bdm_irx;
-
-/* References to BDMFS_FATFS.IRX */
-extern unsigned char bdmfs_fatfs_irx[] __attribute__((aligned(16)));
-extern unsigned int size_bdmfs_fatfs_irx;
-
-/* References to USBD.IRX */
-extern unsigned char usbd_irx[] __attribute__((aligned(16)));
-extern unsigned int size_usbd_irx;
-
-/* References to USBMASS_BD.IRX */
-extern unsigned char usbmass_bd_irx[] __attribute__((aligned(16)));
-extern unsigned int size_usbmass_bd_irx;
+EXTERN_IRX(bdm_irx);
+EXTERN_IRX(bdmfs_fatfs_irx);
+EXTERN_IRX(usbmass_bd_irx);
 
 #ifdef F_internals_ps2_usb_driver
 enum USB_INIT_STATUS __usb_init_status = USB_INIT_STATUS_UNKNOWN;
-int32_t __bdm_id = -1;
-int32_t __bdmfs_fatfs_id = -1;
-int32_t __usbmass_bd_id = -1;
+DECL_IRX_VARS(bdm);
+DECL_IRX_VARS(bdmfs_fatfs);
+DECL_IRX_VARS(usbmass_bd);
 #else
 extern enum USB_INIT_STATUS __usb_init_status;
-extern int32_t __bdm_id;
-extern int32_t __bdmfs_fatfs_id;
-extern int32_t __usbmass_bd_id;
+EXTERN_IRX_VARS(bdm);
+EXTERN_IRX_VARS(bdmfs_fatfs);
+EXTERN_IRX_VARS(usbmass_bd);
 #endif
 
 #ifdef F_init_ps2_usb_driver
 static enum USB_INIT_STATUS loadIRXs(void) {
     /* BDM.IRX */
-    __bdm_id = SifExecModuleBuffer(&bdm_irx, size_bdm_irx, 0, NULL, NULL);
-    if (__bdm_id < 0)
+    __bdm_id = SifExecModuleBuffer(&bdm_irx, size_bdm_irx, 0, NULL, &__bdm_ret);
+    if (CHECK_IRX_ERR(bdm))
         return USB_INIT_STATUS_BDM_IRX_ERROR;
 
     /* BDMFS_FATFS.IRX */
-    __bdmfs_fatfs_id = SifExecModuleBuffer(&bdmfs_fatfs_irx, size_bdmfs_fatfs_irx, 0, NULL, NULL);
-    if (__bdmfs_fatfs_id < 0)
+    __bdmfs_fatfs_id = SifExecModuleBuffer(&bdmfs_fatfs_irx, size_bdmfs_fatfs_irx, 0, NULL, &__bdmfs_fatfs_ret);
+    if (CHECK_IRX_ERR(bdmfs_fatfs))
         return USB_INIT_STATUS_BDMFS_FATFS_IRX_ERROR;
 
     /* USBD.IRX */
     init_usbd_driver();
 
     /* USBMASS_BD.IRX */
-    __usbmass_bd_id = SifExecModuleBuffer(&usbmass_bd_irx, size_usbmass_bd_irx, 0, NULL, NULL);
-    if (__usbmass_bd_id < 0)
+    __usbmass_bd_id = SifExecModuleBuffer(&usbmass_bd_irx, size_usbmass_bd_irx, 0, NULL, &__usbmass_bd_ret);
+    if (CHECK_IRX_ERR(usbmass_bd))
         return USB_INIT_STATUS_USBMASS_BD_IRX_ERROR;
 
     return USB_INIT_STATUS_IRX_OK;
@@ -80,24 +69,24 @@ enum USB_INIT_STATUS init_usb_driver() {
 #ifdef F_deinit_ps2_usb_driver
 static void unloadIRXs(void) {
     /* USBMASS_BD.IRX */
-    if (__usbmass_bd_id > 0) {
+    if (CHECK_IRX_UNLOAD(usbmass_bd)) {
         SifUnloadModule(__usbmass_bd_id);
-        __usbmass_bd_id = -1;
+        RESET_IRX_VARS(usbmass_bd);
     }
 
     /* USBD.IRX */
     deinit_usbd_driver();
 
     /* BDMFS_FATFS.IRX */
-    if (__bdmfs_fatfs_id > 0) {
+    if (CHECK_IRX_UNLOAD(bdmfs_fatfs)) {
         SifUnloadModule(__bdmfs_fatfs_id);
-        __bdmfs_fatfs_id = -1;
+        RESET_IRX_VARS(bdmfs_fatfs);
     }
 
     /* BDM.IRX */
-    if (__bdm_id > 0) {
+    if (CHECK_IRX_UNLOAD(bdm)) {
         SifUnloadModule(__bdm_id);
-        __bdm_id = -1;
+        RESET_IRX_VARS(bdm);
     }
 }
 

--- a/src/ps2_usbd_driver.c
+++ b/src/ps2_usbd_driver.c
@@ -13,27 +13,26 @@
 #include <stdint.h>
 #include <stddef.h>
 #include <ps2_usbd_driver.h>
+#include <irx_common_macros.h>
 
 #include <sifrpc.h>
 #include <loadfile.h>
 
-/* References to USBD.IRX */
-extern unsigned char usbd_irx[] __attribute__((aligned(16)));
-extern unsigned int size_usbd_irx;
+EXTERN_IRX(usbd_irx);
 
 #ifdef F_internals_ps2_usbd_driver
 enum USBD_INIT_STATUS __usbd_init_status = USBD_INIT_STATUS_UNKNOWN;
-int32_t __usbd_id = -1;
+DECL_IRX_VARS(usbd);
 #else
 extern enum USBD_INIT_STATUS __usbd_init_status;
-extern int32_t __usbd_id;
+EXTERN_IRX_VARS(usbd);
 #endif
 
 #ifdef F_init_ps2_usbd_driver
 static enum USBD_INIT_STATUS loadIRXs(void) {
     /* USBD.IRX */
-    __usbd_id = SifExecModuleBuffer(&usbd_irx, size_usbd_irx, 0, NULL, NULL);
-    if (__usbd_id < 0)
+    __usbd_id = SifExecModuleBuffer(&usbd_irx, size_usbd_irx, 0, NULL, &__usbd_ret);
+    if (CHECK_IRX_ERR(usbd))
         return USBD_INIT_STATUS_IRX_ERROR;
 
     return USBD_INIT_STATUS_OK;
@@ -48,9 +47,9 @@ enum USBD_INIT_STATUS init_usbd_driver() {
 #ifdef F_deinit_ps2_usbd_driver
 static void unloadIRXs(void) {
     /* USBD.IRX */
-    if (__usbd_id > 0) {
+    if (CHECK_IRX_UNLOAD(usbd)) {
         SifUnloadModule(__usbd_id);
-        __usbd_id = -1;
+        RESET_IRX_VARS(usbd);
     }
 }
 


### PR DESCRIPTION
Now both module loading and module unloading have decent conditions.

a successfully loaded IRX driver will have positive number as ID and either 1 or 2 for return value (unless that IRX has no need for resident code, see adddrv.irx and freeram.irx as samples of this)

Also, now the module unloading has decent conditions, a module can only be unloaded if appropiate MODLOAD version is running on the IOP and if module returned 2 (MODULE REMOVABLE END)
We only have to check for IRX return value, since the IRX themselves check the moadload version before proceeding