### PR TITLE
Improve irx loading

### DIFF
--- a/include/irx_common_macros.h
+++ b/include/irx_common_macros.h
@@ -15,6 +15,9 @@
     __##irx##_id = -1; \
     __##irx##_ret = -1
 
+/// condition to perform irx load
+#define CHECK_IRX_LOAD(irx) (__##irx##_id == -1) && (__##irx##_ret == -1)
+
 /// condition for irx startup errors
 #define CHECK_IRX_ERR(irx) (__##irx##_id < 0 || __##irx##_ret == 1)
 

--- a/include/ps2_filesystem_driver.h
+++ b/include/ps2_filesystem_driver.h
@@ -21,6 +21,7 @@
 #include <ps2_memcard_driver.h>
 #include <ps2_usb_driver.h>
 #include <ps2_cdfs_driver.h>
+#include <ps2_dev9_driver.h>
 #include <ps2_hdd_driver.h>
 
 #ifdef __cplusplus

--- a/src/ps2_audio_driver.c
+++ b/src/ps2_audio_driver.c
@@ -35,14 +35,18 @@ EXTERN_IRX_VARS(audsrv);
 #ifdef F_init_ps2_audio_driver
 static enum AUDIO_INIT_STATUS loadIRXs(void) {
     /* LIBSD.IRX */
-    __libsd_id = SifExecModuleBuffer(&libsd_irx, size_libsd_irx, 0, NULL, &__libsd_ret);
-    if (CHECK_IRX_ERR(libsd))
-        return AUDIO_INIT_STATUS_LIBSD_IRX_ERROR;
+    if (CHECK_IRX_LOAD(libsd)) {
+        __libsd_id = SifExecModuleBuffer(&libsd_irx, size_libsd_irx, 0, NULL, &__libsd_ret);
+        if (CHECK_IRX_ERR(libsd))
+            return AUDIO_INIT_STATUS_LIBSD_IRX_ERROR;
+    }
 
     /* AUDSRV.IRX */
-    __audsrv_id = SifExecModuleBuffer(&audsrv_irx, size_audsrv_irx, 0, NULL, &__audsrv_ret);
-    if (CHECK_IRX_ERR(audsrv))
-        return AUDIO_INIT_STATUS_AUDSRV_IRX_ERROR;
+    if (CHECK_IRX_LOAD(audsrv)) {
+        __audsrv_id = SifExecModuleBuffer(&audsrv_irx, size_audsrv_irx, 0, NULL, &__audsrv_ret);
+        if (CHECK_IRX_ERR(audsrv))
+            return AUDIO_INIT_STATUS_AUDSRV_IRX_ERROR;
+    }
 
     return AUDIO_INIT_STATUS_IRX_OK;
 }

--- a/src/ps2_camera_driver.c
+++ b/src/ps2_camera_driver.c
@@ -40,9 +40,11 @@ static enum CAMERA_INIT_STATUS loadIRXs(bool init_dependencies) {
     }
 
     /* PSCAM.IRX */
-    __camera_id = SifExecModuleBuffer(&ps2cam_irx, size_ps2cam_irx, 0, NULL, &__camera_ret);
-    if (CHECK_IRX_ERR(camera))
-        return CAMERA_INIT_STATUS_IRX_ERROR;
+    if (CHECK_IRX_LOAD(camera)) {
+        __camera_id = SifExecModuleBuffer(&ps2cam_irx, size_ps2cam_irx, 0, NULL, &__camera_ret);
+        if (CHECK_IRX_ERR(camera))
+            return CAMERA_INIT_STATUS_IRX_ERROR;
+    }
 
     return CAMERA_INIT_STATUS_IRX_OK;
 }

--- a/src/ps2_cdfs_driver.c
+++ b/src/ps2_cdfs_driver.c
@@ -32,9 +32,11 @@ EXTERN_IRX_VARS(cdfs);
 #ifdef F_init_ps2_cdfs_driver
 static enum CDFS_INIT_STATUS loadIRXs(void) {
     /* CDFS.IRX */
-    __cdfs_id = SifExecModuleBuffer(&cdfs_irx, size_cdfs_irx, 0, NULL, &__cdfs_ret);
-    if (CHECK_IRX_ERR(cdfs))
-        return CDFS_INIT_STATUS_IRX_ERROR;
+    if (CHECK_IRX_LOAD(cdfs)) {
+        __cdfs_id = SifExecModuleBuffer(&cdfs_irx, size_cdfs_irx, 0, NULL, &__cdfs_ret);
+        if (CHECK_IRX_ERR(cdfs))
+            return CDFS_INIT_STATUS_IRX_ERROR;
+    }
 
     return CDFS_INIT_STATUS_IRX_OK;
 }

--- a/src/ps2_fileXio_driver.c
+++ b/src/ps2_fileXio_driver.c
@@ -39,14 +39,18 @@ EXTERN_IRX_VARS(fileXio);
 #ifdef F_init_ps2_fileXio_driver
 static enum FILEXIO_INIT_STATUS loadIRXs(void) {
     /* IOMANX.IRX */
-    __iomanX_id = SifExecModuleBuffer(&iomanX_irx, size_iomanX_irx, 0, NULL, &__iomanX_ret);
-    if (CHECK_IRX_ERR(iomanX))
-        return FILEXIO_INIT_STATUS_IOMANX_IRX_ERROR;
+    if (CHECK_IRX_LOAD(iomanX)) {
+        __iomanX_id = SifExecModuleBuffer(&iomanX_irx, size_iomanX_irx, 0, NULL, &__iomanX_ret);
+        if (CHECK_IRX_ERR(iomanX))
+            return FILEXIO_INIT_STATUS_IOMANX_IRX_ERROR;
+    }
 
     /* FILEXIO.IRX */
-    __fileXio_id = SifExecModuleBuffer(&fileXio_irx, size_fileXio_irx, 0, NULL, &__fileXio_ret);
-    if (CHECK_IRX_ERR(fileXio))
-        return FILEXIO_INIT_STATUS_FILEXIO_IRX_ERROR;
+    if (CHECK_IRX_LOAD(fileXio)) {
+        __fileXio_id = SifExecModuleBuffer(&fileXio_irx, size_fileXio_irx, 0, NULL, &__fileXio_ret);
+        if (CHECK_IRX_ERR(fileXio))
+            return FILEXIO_INIT_STATUS_FILEXIO_IRX_ERROR;
+    }
 
     return FILEXIO_INIT_STATUS_IRX_OK;
 }

--- a/src/ps2_filesystem_driver.c
+++ b/src/ps2_filesystem_driver.c
@@ -73,6 +73,7 @@ void __internal_deinit_ps2_filesystem_driver(bool deinit_powerOff) {
     deinit_usb_driver();
     deinit_memcard_driver(true);
     deinit_fileXio_driver();
+    deinit_dev9_driver();
 
     if (deinit_powerOff)
         deinit_poweroff_driver();
@@ -103,6 +104,7 @@ void init_ps2_filesystem_driver() {
     init_memcard_driver(true);
     init_usb_driver();
     init_cdfs_driver();
+    init_dev9_driver();
     init_hdd_driver(false, true);
 
     poweroffSetCallback(&poweroffHandler, NULL);

--- a/src/ps2_hdd_driver.c
+++ b/src/ps2_hdd_driver.c
@@ -80,23 +80,29 @@ static enum HDD_INIT_STATUS loadIRXs(void) {
                     "20";
 
     /* PS2ATAD.IRX */
-    __ps2atad_id = SifExecModuleBuffer(&ps2atad_irx, size_ps2atad_irx, 0, NULL, &__ps2atad_ret);
-    if (CHECK_IRX_ERR(ps2atad))
-        return HDD_INIT_STATUS_PS2ATAD_IRX_ERROR;
+    if (CHECK_IRX_LOAD(ps2atad)) {
+       __ps2atad_id = SifExecModuleBuffer(&ps2atad_irx, size_ps2atad_irx, 0, NULL, &__ps2atad_ret);
+        if (CHECK_IRX_ERR(ps2atad))
+            return HDD_INIT_STATUS_PS2ATAD_IRX_ERROR;
+    }
 
     /* PS2HDD.IRX */
-    __ps2hdd_id = SifExecModuleBuffer(&ps2hdd_irx, size_ps2hdd_irx, sizeof(hddarg), hddarg, &__ps2hdd_ret);
-    if (CHECK_IRX_ERR(ps2hdd))
-        return HDD_INIT_STATUS_PS2HDD_IRX_ERROR;
+    if (CHECK_IRX_LOAD(ps2hdd)) {
+        __ps2hdd_id = SifExecModuleBuffer(&ps2hdd_irx, size_ps2hdd_irx, sizeof(hddarg), hddarg, &__ps2hdd_ret);
+        if (CHECK_IRX_ERR(ps2hdd))
+            return HDD_INIT_STATUS_PS2HDD_IRX_ERROR;
+    }
 
     /* Check if HDD is formatted and ready to be used */
     if (hddCheck() < 0)
         return HDD_INIT_STATUS_HDD_NOT_READY_ERROR;
 
     /* PS2FS.IRX */
-    __ps2fs_id = SifExecModuleBuffer(&ps2fs_irx, size_ps2fs_irx, 0, NULL, &__ps2fs_ret);
-    if (CHECK_IRX_ERR(ps2fs))
-        return HDD_INIT_STATUS_PS2FS_IRX_ERROR;
+    if (CHECK_IRX_LOAD(ps2fs)) {
+        __ps2fs_id = SifExecModuleBuffer(&ps2fs_irx, size_ps2fs_irx, 0, NULL, &__ps2fs_ret);
+        if (CHECK_IRX_ERR(ps2fs))
+            return HDD_INIT_STATUS_PS2FS_IRX_ERROR;
+    }
 
     return HDD_INIT_STATUS_IRX_OK;
 }
@@ -301,9 +307,6 @@ void umount_hdd_partition(const char *mountpoint) {
         __mount_status = HDD_MOUNT_STATUS_UKNOWN;
         memset(__mountString, 0, 10);
     }
-
-    if (__ps2fs_id > 0)
-        fileXioDevctl("dev9x:", DDIOC_OFF, NULL, 0, NULL, 0);
 }
 #else
 void umount_hdd_partition(const char *mountpoint);

--- a/src/ps2_hdd_driver.c
+++ b/src/ps2_hdd_driver.c
@@ -136,7 +136,6 @@ static void unloadIRXs(void) {
     if (CHECK_IRX_UNLOAD(ps2fs)) {
         SifUnloadModule(__ps2fs_id);
         RESET_IRX_VARS(ps2fs);
-        __ps2fs_id = -1;
     }
 
     /* PS2HDD.IRX */
@@ -149,7 +148,6 @@ static void unloadIRXs(void) {
     if (CHECK_IRX_UNLOAD(ps2atad)) {
         SifUnloadModule(__ps2atad_id);
         RESET_IRX_VARS(ps2atad);
-        __ps2atad_id = -1;
     }
 }
 

--- a/src/ps2_iopip_driver.c
+++ b/src/ps2_iopip_driver.c
@@ -37,14 +37,18 @@ EXTERN_IRX_VARS(ps2ips);
 #ifdef F_init_ps2_iopip_driver
 static enum IOPIP_INIT_STATUS loadIRXs(void) {
     /* PS2IP_NM.IRX */
-    __ps2ip_nm_id = SifExecModuleBuffer(&ps2ip_nm_irx, size_ps2ip_nm_irx, 0, NULL, &__ps2ip_nm_ret);
-    if (CHECK_IRX_ERR(ps2ip_nm))
-        return IOPIP_INIT_STATUS_PS2IP_NM_IRX_ERROR;
+    if (CHECK_IRX_LOAD(ps2ip_nm)) {
+        __ps2ip_nm_id = SifExecModuleBuffer(&ps2ip_nm_irx, size_ps2ip_nm_irx, 0, NULL, &__ps2ip_nm_ret);
+        if (CHECK_IRX_ERR(ps2ip_nm))
+            return IOPIP_INIT_STATUS_PS2IP_NM_IRX_ERROR;
+    }
     
     /* PS2IPS.IRX */
-    __ps2ips_id = SifExecModuleBuffer(&ps2ips_irx, size_ps2ips_irx, 0, NULL, &__ps2ips_ret);
-    if (CHECK_IRX_ERR(ps2ips))
-        return IOPIP_INIT_STATUS_PS2IPS_IRX_ERROR;
+    if (CHECK_IRX_LOAD(ps2ips)) {
+        __ps2ips_id = SifExecModuleBuffer(&ps2ips_irx, size_ps2ips_irx, 0, NULL, &__ps2ips_ret);
+        if (CHECK_IRX_ERR(ps2ips))
+            return IOPIP_INIT_STATUS_PS2IPS_IRX_ERROR;
+    }
 
     return IOPIP_INIT_STATUS_OK;
 }

--- a/src/ps2_joystick_driver.c
+++ b/src/ps2_joystick_driver.c
@@ -39,14 +39,18 @@ EXTERN_IRX_VARS(padman);
 #ifdef F_init_ps2_joystick_driver
 static enum JOYSTICK_INIT_STATUS loadIRXs(void) {
     /* MTAPMAN.IRX */
-    __mtapman_id = SifExecModuleBuffer(&mtapman_irx, size_mtapman_irx, 0, NULL, &__mtapman_ret);
-    if (CHECK_IRX_ERR(mtapman))
-        return JOYSTICK_INIT_STATUS_MTAP_IRX_ERROR;
+    if (CHECK_IRX_LOAD(mtapman)) {
+        __mtapman_id = SifExecModuleBuffer(&mtapman_irx, size_mtapman_irx, 0, NULL, &__mtapman_ret);
+        if (CHECK_IRX_ERR(mtapman))
+            return JOYSTICK_INIT_STATUS_MTAP_IRX_ERROR;
+    }
 
     /* PADMAN.IRX */
-    __padman_id = SifExecModuleBuffer(&padman_irx, size_padman_irx, 0, NULL, &__padman_ret);
-    if (CHECK_IRX_ERR(padman))
-        return JOYSTICK_INIT_STATUS_PAD_IRX_ERROR;
+    if (CHECK_IRX_LOAD(padman)) {
+        __padman_id = SifExecModuleBuffer(&padman_irx, size_padman_irx, 0, NULL, &__padman_ret);
+        if (CHECK_IRX_ERR(padman))
+            return JOYSTICK_INIT_STATUS_PAD_IRX_ERROR;
+    }
 
     return JOYSTICK_INIT_STATUS_IRX_OK;
 }

--- a/src/ps2_keyboard_driver.c
+++ b/src/ps2_keyboard_driver.c
@@ -39,9 +39,11 @@ static enum KEYBOARD_INIT_STATUS loadIRXs(bool init_dependencies) {
     }
 
     /* PS2KBD.IRX */
-    __keyboard_id = SifExecModuleBuffer(&ps2kbd_irx, size_ps2kbd_irx, 0, NULL, &__keyboard_ret);
-    if (CHECK_IRX_ERR(keyboard))
-        return KEYBOARD_INIT_STATUS_IRX_ERROR;
+    if (CHECK_IRX_LOAD(keyboard)) {
+        __keyboard_id = SifExecModuleBuffer(&ps2kbd_irx, size_ps2kbd_irx, 0, NULL, &__keyboard_ret);
+        if (CHECK_IRX_ERR(keyboard))
+            return KEYBOARD_INIT_STATUS_IRX_ERROR;
+    }
 
     return KEYBOARD_INIT_STATUS_IRX_OK;
 }

--- a/src/ps2_memcard_driver.c
+++ b/src/ps2_memcard_driver.c
@@ -36,14 +36,18 @@ EXTERN_IRX_VARS(mcserv);
 #ifdef F_init_ps2_memcard_driver
 static enum MEMCARD_INIT_STATUS loadIRXs(void) {
     /* MCMAN.IRX */
-    __mcman_id = SifExecModuleBuffer(&mcman_irx, size_mcman_irx, 0, NULL, &__mcman_ret);
-    if (CHECK_IRX_ERR(mcman))
-        return MEMCARD_INIT_STATUS_MCMAN_IRX_ERROR;
+    if (CHECK_IRX_LOAD(mcman)) {
+        __mcman_id = SifExecModuleBuffer(&mcman_irx, size_mcman_irx, 0, NULL, &__mcman_ret);
+        if (CHECK_IRX_ERR(mcman))
+            return MEMCARD_INIT_STATUS_MCMAN_IRX_ERROR;
+    }
 
     /* MCSERV.IRX */
-    __mcserv_id = SifExecModuleBuffer(&mcserv_irx, size_mcserv_irx, 0, NULL, &__mcserv_ret);
-    if (CHECK_IRX_ERR(mcserv))
-        return MEMCARD_INIT_STATUS_MCSERV_IRX_ERROR;
+    if (CHECK_IRX_LOAD(mcserv)) {
+        __mcserv_id = SifExecModuleBuffer(&mcserv_irx, size_mcserv_irx, 0, NULL, &__mcserv_ret);
+        if (CHECK_IRX_ERR(mcserv))
+            return MEMCARD_INIT_STATUS_MCSERV_IRX_ERROR;
+    }
 
     return MEMCARD_INIT_STATUS_IRX_OK;
 }

--- a/src/ps2_mouse_driver.c
+++ b/src/ps2_mouse_driver.c
@@ -40,9 +40,11 @@ static enum MOUSE_INIT_STATUS loadIRXs(bool init_dependencies) {
     }
 
     /* PS2MOUSE.IRX */
-    __mouse_id = SifExecModuleBuffer(&ps2mouse_irx, size_ps2mouse_irx, 0, NULL, &__mouse_ret);
-    if (CHECK_IRX_ERR(mouse))
-        return MOUSE_INIT_STATUS_IRX_ERROR;
+    if (CHECK_IRX_LOAD(mouse)) {
+        __mouse_id = SifExecModuleBuffer(&ps2mouse_irx, size_ps2mouse_irx, 0, NULL, &__mouse_ret);
+        if (CHECK_IRX_ERR(mouse))
+            return MOUSE_INIT_STATUS_IRX_ERROR;
+    }
 
     return MOUSE_INIT_STATUS_IRX_OK;
 }

--- a/src/ps2_netman_driver.c
+++ b/src/ps2_netman_driver.c
@@ -32,12 +32,11 @@ EXTERN_IRX_VARS(netman);
 #ifdef F_init_ps2_netman_driver
 static enum NETMAN_INIT_STATUS loadIRXs(void) {
     /* NETMAN.IRX */
-    if (__netman_id > 0)
-        return NETMAN_INIT_STATUS_OK;
-
-    __netman_id = SifExecModuleBuffer(&netman_irx, size_netman_irx, 0, NULL, &__netman_ret);
-    if (CHECK_IRX_ERR(netman))
-        return NETMAN_INIT_STATUS_IRX_ERROR;
+    if (CHECK_IRX_LOAD(netman)) {
+        __netman_id = SifExecModuleBuffer(&netman_irx, size_netman_irx, 0, NULL, &__netman_ret);
+        if (CHECK_IRX_ERR(netman))
+            return NETMAN_INIT_STATUS_IRX_ERROR;
+    }
 
     return NETMAN_INIT_STATUS_IRX_OK;
 }

--- a/src/ps2_poweroff_driver.c
+++ b/src/ps2_poweroff_driver.c
@@ -31,9 +31,11 @@ EXTERN_IRX_VARS(poweroff);
 #ifdef F_init_ps2_poweroff_driver
 static enum POWEROFF_INIT_STATUS loadIRXs(void) {
     /* POWEROFF.IRX */
-    __poweroff_id = SifExecModuleBuffer(&poweroff_irx, size_poweroff_irx, 0, NULL, &__poweroff_ret);
-    if (CHECK_IRX_ERR(poweroff))
-        return POWEROFF_INIT_STATUS_IRX_ERROR;
+    if (CHECK_IRX_LOAD(poweroff)) {
+        __poweroff_id = SifExecModuleBuffer(&poweroff_irx, size_poweroff_irx, 0, NULL, &__poweroff_ret);
+        if (CHECK_IRX_ERR(poweroff))
+            return POWEROFF_INIT_STATUS_IRX_ERROR;
+    }
 
     return POWEROFF_INIT_STATUS_IRX_OK;
 }

--- a/src/ps2_sio2man_driver.c
+++ b/src/ps2_sio2man_driver.c
@@ -30,12 +30,11 @@ EXTERN_IRX_VARS(sio2man);
 #ifdef F_init_ps2_sio2man_driver
 static enum SIO2MAN_INIT_STATUS loadIRXs(void) {
     /* SIO2MAN.IRX */
-    if (__sio2man_id > 0)
-        return SIO2MAN_INIT_STATUS_OK;
-
-    __sio2man_id = SifExecModuleBuffer(&sio2man_irx, size_sio2man_irx, 0, NULL, &__sio2man_ret);
-    if (CHECK_IRX_ERR(sio2man))
-        return SIO2MAN_INIT_STATUS_IRX_ERROR;
+    if (CHECK_IRX_LOAD(sio2man)) {
+        __sio2man_id = SifExecModuleBuffer(&sio2man_irx, size_sio2man_irx, 0, NULL, &__sio2man_ret);
+        if (CHECK_IRX_ERR(sio2man))
+            return SIO2MAN_INIT_STATUS_IRX_ERROR;
+    }
 
     return SIO2MAN_INIT_STATUS_OK;
 }

--- a/src/ps2_smap_driver.c
+++ b/src/ps2_smap_driver.c
@@ -30,12 +30,11 @@ EXTERN_IRX_VARS(smap);
 #ifdef F_init_ps2_smap_driver
 static enum SMAP_INIT_STATUS loadIRXs(void) {
     /* SMAP.IRX */
-    if (__smap_id > 0)
-        return SMAP_INIT_STATUS_OK;
-
-    __smap_id = SifExecModuleBuffer(&smap_irx, size_smap_irx, 0, NULL, &__smap_ret);
-    if (CHECK_IRX_ERR(smap))
-        return SMAP_INIT_STATUS_IRX_ERROR;
+    if (CHECK_IRX_LOAD(smap)) {
+        __smap_id = SifExecModuleBuffer(&smap_irx, size_smap_irx, 0, NULL, &__smap_ret);
+        if (CHECK_IRX_ERR(smap))
+            return SMAP_INIT_STATUS_IRX_ERROR;
+    }
 
     return SMAP_INIT_STATUS_OK;
 }

--- a/src/ps2_usb_driver.c
+++ b/src/ps2_usb_driver.c
@@ -39,22 +39,28 @@ EXTERN_IRX_VARS(usbmass_bd);
 #ifdef F_init_ps2_usb_driver
 static enum USB_INIT_STATUS loadIRXs(void) {
     /* BDM.IRX */
-    __bdm_id = SifExecModuleBuffer(&bdm_irx, size_bdm_irx, 0, NULL, &__bdm_ret);
-    if (CHECK_IRX_ERR(bdm))
-        return USB_INIT_STATUS_BDM_IRX_ERROR;
+    if (CHECK_IRX_LOAD(bdm)) {
+        __bdm_id = SifExecModuleBuffer(&bdm_irx, size_bdm_irx, 0, NULL, &__bdm_ret);
+        if (CHECK_IRX_ERR(bdm))
+            return USB_INIT_STATUS_BDM_IRX_ERROR;
+    }
 
     /* BDMFS_FATFS.IRX */
-    __bdmfs_fatfs_id = SifExecModuleBuffer(&bdmfs_fatfs_irx, size_bdmfs_fatfs_irx, 0, NULL, &__bdmfs_fatfs_ret);
-    if (CHECK_IRX_ERR(bdmfs_fatfs))
-        return USB_INIT_STATUS_BDMFS_FATFS_IRX_ERROR;
+    if (CHECK_IRX_LOAD(bdmfs_fatfs)) {
+        __bdmfs_fatfs_id = SifExecModuleBuffer(&bdmfs_fatfs_irx, size_bdmfs_fatfs_irx, 0, NULL, &__bdmfs_fatfs_ret);
+        if (CHECK_IRX_ERR(bdmfs_fatfs))
+            return USB_INIT_STATUS_BDMFS_FATFS_IRX_ERROR;
+    }
 
     /* USBD.IRX */
     init_usbd_driver();
 
     /* USBMASS_BD.IRX */
-    __usbmass_bd_id = SifExecModuleBuffer(&usbmass_bd_irx, size_usbmass_bd_irx, 0, NULL, &__usbmass_bd_ret);
-    if (CHECK_IRX_ERR(usbmass_bd))
-        return USB_INIT_STATUS_USBMASS_BD_IRX_ERROR;
+    if (CHECK_IRX_LOAD(usbmass_bd)) {
+        __usbmass_bd_id = SifExecModuleBuffer(&usbmass_bd_irx, size_usbmass_bd_irx, 0, NULL, &__usbmass_bd_ret);
+        if (CHECK_IRX_ERR(usbmass_bd))
+            return USB_INIT_STATUS_USBMASS_BD_IRX_ERROR;
+    }
 
     return USB_INIT_STATUS_IRX_OK;
 }

--- a/src/ps2_usbd_driver.c
+++ b/src/ps2_usbd_driver.c
@@ -31,9 +31,11 @@ EXTERN_IRX_VARS(usbd);
 #ifdef F_init_ps2_usbd_driver
 static enum USBD_INIT_STATUS loadIRXs(void) {
     /* USBD.IRX */
-    __usbd_id = SifExecModuleBuffer(&usbd_irx, size_usbd_irx, 0, NULL, &__usbd_ret);
-    if (CHECK_IRX_ERR(usbd))
-        return USBD_INIT_STATUS_IRX_ERROR;
+    if (CHECK_IRX_LOAD(usbd)) {
+        __usbd_id = SifExecModuleBuffer(&usbd_irx, size_usbd_irx, 0, NULL, &__usbd_ret);
+        if (CHECK_IRX_ERR(usbd))
+            return USBD_INIT_STATUS_IRX_ERROR;
+    }
 
     return USBD_INIT_STATUS_OK;
 }


### PR DESCRIPTION
This PR does 2 different things:
1. Skip the loading of the IRXs if the status is different than the initial value, in this way, we can avoid issues when drivers have some dependencies.
2. Improve deinit of dev9 driver.